### PR TITLE
Handle missing AI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ export const AI_CONFIG = {
   2. Install dependencies with `npm install`.
   3. Start the dev server using `npm run dev`.
 
+### Manual Task Entry Without AI
+
+If no AI API key is provided, the app will not call an AI model. In this case you
+can still enter tasks directly in the Markdown area. Use clear project tags and
+task items, e.g.:
+
+```markdown
+#abc-project
+- [ ] Add API
+```
+
+Press **Generate Tasks** and the tasks will be parsed locally without any AI
+requests.
+
 ## UI Layout
 
 ```

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -1,6 +1,10 @@
 import { AI_CONFIG } from '../config/aiConfig.js';
 
 export async function generateTasks(markdown) {
+  if (!AI_CONFIG.apiKey || !AI_CONFIG.model || !AI_CONFIG.endpoint) {
+    // If AI isn't configured, return the raw markdown so it can be parsed manually
+    return markdown;
+  }
   const messages = [
     { role: 'system', content: 'Extract concise tasks grouped by hashtags.' },
     { role: 'user', content: markdown }


### PR DESCRIPTION
## Summary
- handle missing AI key in `generateTasks`
- document manual task entry when AI isn't configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856009c09ac83228ab636d966e0b365