### PR TITLE
Fix project name parsing

### DIFF
--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -3,9 +3,9 @@ export function parseProjects(markdown) {
   const projects = {};
   let currentProject = 'General';
   for (const line of lines) {
-    const projectTag = line.match(/#(\w+)/);
+    const projectTag = line.match(/^#\s*(.+)$/);
     if (projectTag) {
-      currentProject = projectTag[1];
+      currentProject = projectTag[1].trim();
       projects[currentProject] = projects[currentProject] || [];
     }
     const taskMatch = line.match(/- \[ \] (.+)/);

--- a/src/utils/markdownParser.test.js
+++ b/src/utils/markdownParser.test.js
@@ -16,4 +16,10 @@ describe('parseProjects', () => {
     const result = parseProjects(input);
     expect(result).toEqual({ General: ['general task'] });
   });
+
+  it('handles hyphenated and spaced project names', () => {
+    const input = `#test project-api\n- [ ] task`;
+    const result = parseProjects(input);
+    expect(result).toEqual({ 'test project-api': ['task'] });
+  });
 });


### PR DESCRIPTION
## Summary
- support more flexible project names in `parseProjects`
- test project names with hyphen and spaces

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685602c74374832282b5e10f2f37f5b1