### PR TITLE
Clarify AI extraction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This project implements a web-based AI-powered task extraction tool. It converts
 ### Task Extraction & Grouping
 
 * Use configurable AI models (OpenAI GPT-4, OpenRouter API).
-* Generate concise, actionable tasks.
+* Generate concise, actionable tasks from whatever notes the user enters.
+* When AI is configured, free-form text is transformed into a markdown task list grouped by `#<project-name>` headings.
 * Group tasks by detected project tags, with untagged tasks grouped under a default "General" category.
 
 ### CRUD Operations Abstraction
@@ -86,6 +87,29 @@ export const AI_CONFIG = {
   1. Copy `.env.example` to `.env` and set `VITE_AI_API_KEY`.
   2. Install dependencies with `npm install`.
   3. Start the dev server using `npm run dev`.
+
+### AI-Powered Extraction
+
+With a valid AI configuration the input box can contain any raw notes or "stream
+of consciousness" text. Press **Generate Tasks** and the model will respond with
+a markdown list grouped by `#<project-name>` headings. Untagged items are placed
+under `#General`.
+
+Example input:
+
+```text
+Today I need to fix login for #webapp and also update the #docs about API tokens.
+```
+
+Possible AI output:
+
+```markdown
+# webapp
+- [ ] Fix login
+
+# docs
+- [ ] Update API tokens section
+```
 
 ### Manual Task Entry Without AI
 

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -1,13 +1,19 @@
 import { AI_CONFIG } from '../config/aiConfig.js';
 
-export async function generateTasks(markdown) {
+// `notes` can be free-form text or markdown describing what is on the user's mind.
+// The AI will turn this into a markdown task list grouped by #project names.
+export async function generateTasks(notes) {
   if (!AI_CONFIG.apiKey || !AI_CONFIG.model || !AI_CONFIG.endpoint) {
     // If AI isn't configured, return the raw markdown so it can be parsed manually
-    return markdown;
+    return notes;
   }
   const messages = [
-    { role: 'system', content: 'Extract concise tasks grouped by hashtags.' },
-    { role: 'user', content: markdown }
+    {
+      role: 'system',
+      content:
+        'From the user notes, extract a markdown task list grouped by project name using "#<project-name>" headings. Use "#General" when no project is provided and return only the list.'
+    },
+    { role: 'user', content: notes }
   ];
 
   const response = await fetch(AI_CONFIG.endpoint, {


### PR DESCRIPTION
## Summary
- clarify that AI converts notes into `#<project>` task lists
- document how AI-powered extraction works
- tweak the system prompt in `aiService` to group tasks by project name

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685604036e7083228f144119fc8e5feb