### PR TITLE
Add Todoist-style inline project tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ task items, e.g.:
 - [ ] Add API
 ```
 
+You can also tag projects inline, Todoist-style:
+
+```markdown
+- [ ] Add API #abc-project
+```
+
 Press **Generate Tasks** and the tasks will be parsed locally without any AI
 requests.
 

--- a/src/components/TaskList.jsx
+++ b/src/components/TaskList.jsx
@@ -18,7 +18,7 @@ export default function TaskList({ tasksByProject }) {
               className="project-title"
               onClick={() => toggle(project)}
             >
-              {project}
+              {'#' + project}
               <span className="task-count">({tasks.length})</span>
             </h3>
             {!isCollapsed && (

--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -7,11 +7,23 @@ export function parseProjects(markdown) {
     if (projectTag) {
       currentProject = projectTag[1].trim();
       projects[currentProject] = projects[currentProject] || [];
+      continue;
     }
+
     const taskMatch = line.match(/- \[ \] (.+)/);
     if (taskMatch) {
-      if (!projects[currentProject]) projects[currentProject] = [];
-      projects[currentProject].push(taskMatch[1]);
+      let text = taskMatch[1].trim();
+      let project = currentProject;
+
+      // Support inline Todoist-style project tags e.g. "task #proj"
+      const inlineTag = text.match(/#([\w-]+)/);
+      if (inlineTag) {
+        project = inlineTag[1];
+        text = text.replace(`#${inlineTag[1]}`, '').trim();
+      }
+
+      if (!projects[project]) projects[project] = [];
+      projects[project].push(text);
     }
   }
   return projects;

--- a/src/utils/markdownParser.test.js
+++ b/src/utils/markdownParser.test.js
@@ -22,4 +22,10 @@ describe('parseProjects', () => {
     const result = parseProjects(input);
     expect(result).toEqual({ 'test project-api': ['task'] });
   });
+
+  it('parses inline project tags like todoist', () => {
+    const input = `- [ ] a task #proj\n- [ ] another #other`;
+    const result = parseProjects(input);
+    expect(result).toEqual({ proj: ['a task'], other: ['another'] });
+  });
 });


### PR DESCRIPTION
## Summary
- support Todoist-style `#project` tags in markdown parser
- show `#` prefix for project titles in UI
- document inline project tags in README
- test inline tag parsing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685632b34bb083228c6e4b40f5114103