### PR TITLE
Improve task parsing and lighten list font

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap"
       rel="stylesheet"
     />
     <title>AI Task Extractor</title>

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,7 @@ body {
   align-items: center;
   margin-bottom: 0.5rem;
   font-size: 0.95rem;
+  font-weight: 300;
 }
 
 .task-item input {
@@ -108,6 +109,10 @@ body {
   width: 1rem;
   height: 1rem;
   accent-color: #db4c3f;
+}
+
+.task-item span {
+  font-weight: 300;
 }
 
 .task-item .completed {

--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -2,11 +2,25 @@ export function parseProjects(markdown) {
   const lines = markdown.split(/\n/);
   const projects = {};
   let currentProject = 'General';
+
   for (const line of lines) {
-    const projectTag = line.match(/^#\s*(.+)$/);
-    if (projectTag) {
-      currentProject = projectTag[1].trim();
+    // Lines that begin with "# " denote a project heading
+    const headingMatch = line.match(/^#+\s+(.+)$/);
+    if (headingMatch) {
+      currentProject = headingMatch[1].trim();
       projects[currentProject] = projects[currentProject] || [];
+      continue;
+    }
+
+    // Allow Todoist-style project prefix, e.g. "#proj Do something"
+    const prefixTag = line.match(/^#([\w-]+)\s+(.+)/);
+    if (prefixTag) {
+      const project = prefixTag[1];
+      let text = prefixTag[2].trim();
+      text = text.replace(/\(0\)/g, '').trim();
+
+      if (!projects[project]) projects[project] = [];
+      projects[project].push(text);
       continue;
     }
 
@@ -26,5 +40,6 @@ export function parseProjects(markdown) {
       projects[project].push(text);
     }
   }
+
   return projects;
 }

--- a/src/utils/markdownParser.test.js
+++ b/src/utils/markdownParser.test.js
@@ -28,4 +28,10 @@ describe('parseProjects', () => {
     const result = parseProjects(input);
     expect(result).toEqual({ proj: ['a task'], other: ['another'] });
   });
+
+  it('parses tasks prefixed with a project tag', () => {
+    const input = `#proj do this\n#other finish that`;
+    const result = parseProjects(input);
+    expect(result).toEqual({ proj: ['do this'], other: ['finish that'] });
+  });
 });


### PR DESCRIPTION
## Summary
- support Todoist-style project prefix in `markdownParser`
- load Inter 300 weight and apply lighter font to tasks
- add tests for new parsing logic

## Testing
- `npx vitest run` *(fails: cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_685633ce342483229299d11dadab1f1f