### PR TITLE
Add task management lifecycle features

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,21 +29,50 @@ export default function App() {
         const merged = { ...prev };
         Object.entries(parsed).forEach(([project, projectTasks]) => {
           if (!merged[project]) merged[project] = [];
-          const uniqueTasks = projectTasks.filter(
-            task => !merged[project].includes(task)
-          );
-          merged[project] = [...merged[project], ...uniqueTasks];
+          projectTasks.forEach(text => {
+            if (!merged[project].some(t => t.text === text)) {
+              const obj = { text, done: false };
+              merged[project].push(obj);
+              storage.createTask(project, obj);
+            }
+          });
         });
         return merged;
-      });
-
-      Object.entries(parsed).forEach(([project, projectTasks]) => {
-        projectTasks.forEach(task => storage.createTask(project, task));
       });
     } catch (err) {
       console.error(err);
       alert('Failed to generate tasks');
     }
+  };
+
+  const handleToggle = async (project, idx) => {
+    setTasks(prev => {
+      const updated = { ...prev };
+      const task = { ...updated[project][idx] };
+      task.done = !task.done;
+      updated[project][idx] = task;
+      storage.updateTask(project, idx, task);
+      return updated;
+    });
+  };
+
+  const handleDelete = async (project, idx) => {
+    setTasks(prev => {
+      const updated = { ...prev };
+      updated[project].splice(idx, 1);
+      storage.deleteTask(project, idx);
+      return updated;
+    });
+  };
+
+  const handleUpdate = async (project, idx, text) => {
+    setTasks(prev => {
+      const updated = { ...prev };
+      const task = { ...updated[project][idx], text };
+      updated[project][idx] = task;
+      storage.updateTask(project, idx, task);
+      return updated;
+    });
   };
 
   return (
@@ -56,7 +85,12 @@ export default function App() {
         />
       </div>
       <div className="tasks-panel">
-        <TaskList tasksByProject={tasks} />
+        <TaskList
+          tasksByProject={tasks}
+          onToggle={handleToggle}
+          onDelete={handleDelete}
+          onUpdate={handleUpdate}
+        />
       </div>
     </div>
   );

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -1,15 +1,57 @@
 import React, { useState } from 'react';
 
-export default function TaskItem({ task }) {
-  const [done, setDone] = useState(false);
+export default function TaskItem({
+  project,
+  index,
+  task,
+  onToggle,
+  onDelete,
+  onUpdate
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [text, setText] = useState(task.text);
+
+  const handleKeyDown = e => {
+    if (e.key === 'Enter') {
+      onUpdate(project, index, text);
+      setIsEditing(false);
+    } else if (e.key === 'Escape') {
+      setText(task.text);
+      setIsEditing(false);
+    }
+  };
+
   return (
-    <li className="task-item">
+    <li className="task-item" style={{ opacity: task.done ? 0.5 : 1 }}>
       <input
         type="checkbox"
-        checked={done}
-        onChange={() => setDone(!done)}
+        checked={task.done}
+        onChange={() => onToggle(project, index)}
       />
-      <span className={done ? 'completed' : ''}>{task}</span>
+      {isEditing ? (
+        <input
+          className="edit-input"
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+      ) : (
+        <span
+          className={task.done ? 'completed' : ''}
+          onDoubleClick={() => setIsEditing(true)}
+        >
+          {task.text}
+        </span>
+      )}
+      <button
+        className="delete-button"
+        onClick={() => {
+          if (confirm('Delete task?')) onDelete(project, index);
+        }}
+      >
+        🗑
+      </button>
     </li>
   );
 }

--- a/src/components/TaskList.jsx
+++ b/src/components/TaskList.jsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import TaskItem from './TaskItem.jsx';
 
-export default function TaskList({ tasksByProject }) {
+export default function TaskList({
+  tasksByProject,
+  onToggle,
+  onDelete,
+  onUpdate
+}) {
   const [collapsed, setCollapsed] = useState({});
 
   const toggle = project => {
@@ -24,7 +29,15 @@ export default function TaskList({ tasksByProject }) {
             {!isCollapsed && (
               <ul>
                 {tasks.map((task, idx) => (
-                  <TaskItem key={idx} task={task} />
+                  <TaskItem
+                    key={idx}
+                    project={project}
+                    index={idx}
+                    task={task}
+                    onToggle={onToggle}
+                    onDelete={onDelete}
+                    onUpdate={onUpdate}
+                  />
                 ))}
               </ul>
             )}

--- a/src/index.css
+++ b/src/index.css
@@ -115,9 +115,29 @@ body {
   font-weight: 300;
 }
 
+.task-item .edit-input {
+  flex: 1;
+  font-family: inherit;
+  font-size: 0.95rem;
+  margin-right: 0.5rem;
+}
+
 .task-item .completed {
   text-decoration: line-through;
   color: #888;
+}
+
+.delete-button {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #888;
+  visibility: hidden;
+}
+
+.task-item:hover .delete-button {
+  visibility: visible;
 }
 
 .project-section {

--- a/src/storage/localStorageTaskService.js
+++ b/src/storage/localStorageTaskService.js
@@ -5,6 +5,12 @@ export class LocalStorageTaskService extends TaskStorage {
     super();
     this.storeKey = 'vibenote-tasks';
     this.tasks = JSON.parse(localStorage.getItem(this.storeKey) || '{}');
+    // Migrate legacy string-based tasks to object format
+    Object.keys(this.tasks).forEach(project => {
+      this.tasks[project] = this.tasks[project].map(t =>
+        typeof t === 'string' ? { text: t, done: false } : t
+      );
+    });
   }
 
   _save() {
@@ -13,8 +19,10 @@ export class LocalStorageTaskService extends TaskStorage {
 
   async createTask(project, task) {
     if (!this.tasks[project]) this.tasks[project] = [];
-    this.tasks[project].push(task);
-    this._save();
+    if (!this.tasks[project].some(t => t.text === task.text)) {
+      this.tasks[project].push(task);
+      this._save();
+    }
   }
 
   async readTasks(project) {

--- a/src/storage/localStorageTaskService.test.js
+++ b/src/storage/localStorageTaskService.test.js
@@ -11,20 +11,20 @@ describe('LocalStorageTaskService', () => {
   });
 
   it('creates and reads tasks', async () => {
-    await service.createTask('proj', 'task 1');
+    await service.createTask('proj', { text: 'task 1', done: false });
     const tasks = await service.readTasks('proj');
-    expect(tasks).toEqual(['task 1']);
+    expect(tasks).toEqual([{ text: 'task 1', done: false }]);
   });
 
   it('updates tasks', async () => {
-    await service.createTask('proj', 'task 1');
-    await service.updateTask('proj', 0, 'updated');
+    await service.createTask('proj', { text: 'task 1', done: false });
+    await service.updateTask('proj', 0, { text: 'updated', done: true });
     const tasks = await service.readTasks('proj');
-    expect(tasks).toEqual(['updated']);
+    expect(tasks).toEqual([{ text: 'updated', done: true }]);
   });
 
   it('deletes tasks', async () => {
-    await service.createTask('proj', 'task 1');
+    await service.createTask('proj', { text: 'task 1', done: false });
     await service.deleteTask('proj', 0);
     const tasks = await service.readTasks('proj');
     expect(tasks).toEqual([]);

--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -3,9 +3,18 @@ export function parseProjects(markdown) {
   const projects = {};
   let currentProject = 'General';
 
-  for (const line of lines) {
-    // Lines that begin with "# " denote a project heading
-    const headingMatch = line.match(/^#+\s+(.+)$/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const next = lines[i + 1] || '';
+    // Lines that denote a project heading
+    let headingMatch = line.match(/^#([\w-]+)$/);
+    if (!headingMatch && next.trim().startsWith('- [ ]')) {
+      headingMatch = line.match(/^#(.+)$/);
+    }
+    if (!headingMatch) {
+      const spaced = line.match(/^#+\s+(.+)$/);
+      if (spaced) headingMatch = spaced;
+    }
     if (headingMatch) {
       currentProject = headingMatch[1].trim();
       projects[currentProject] = projects[currentProject] || [];
@@ -13,7 +22,10 @@ export function parseProjects(markdown) {
     }
 
     // Allow Todoist-style project prefix, e.g. "#proj Do something"
-    const prefixTag = line.match(/^#([\w-]+)\s+(.+)/);
+    let prefixTag = line.match(/^#([\w-]+)\s+(.+)/);
+    if (prefixTag && !prefixTag[2].includes(' ')) {
+      prefixTag = null;
+    }
     if (prefixTag) {
       const project = prefixTag[1];
       let text = prefixTag[2].trim();


### PR DESCRIPTION
## Summary
- support marking tasks done with persistence
- allow editing, deleting and preventing duplicate tasks
- migrate LocalStorage service to task objects
- update markdown parsing for hashtag headings
- tweak TaskList and TaskItem components
- expand styling for editing and deleting tasks

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856571c067883228942a5e97332fb85