### PR TITLE
Implement task deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project implements a web-based AI-powered task extraction tool. It converts
 * Generate concise, actionable tasks from whatever notes the user enters.
 * When AI is configured, free-form text is transformed into a markdown task list grouped by `#<project-name>` headings.
 * Group tasks by detected project tags, with untagged tasks grouped under a default "General" category.
+* Prevent duplicate tasks within the same project.
 
 ### CRUD Operations Abstraction
 

--- a/src/components/MarkdownTaskInput.test.jsx
+++ b/src/components/MarkdownTaskInput.test.jsx
@@ -11,7 +11,7 @@ describe('MarkdownTaskInput', () => {
     const { getByPlaceholderText } = render(
       <MarkdownTaskInput value="" onChange={() => {}} onGenerate={onGenerate} />
     );
-    const textarea = getByPlaceholderText('Enter markdown with tasks...');
+    const textarea = getByPlaceholderText('Enter markdown with tasks... (Press Enter to generate)');
     fireEvent.keyDown(textarea, { key: 'Enter' });
     expect(onGenerate).toHaveBeenCalledTimes(1);
   });

--- a/src/storage/localStorageTaskService.js
+++ b/src/storage/localStorageTaskService.js
@@ -13,8 +13,13 @@ export class LocalStorageTaskService extends TaskStorage {
 
   async createTask(project, task) {
     if (!this.tasks[project]) this.tasks[project] = [];
-    this.tasks[project].push(task);
-    this._save();
+    const getText = t => (typeof t === 'string' ? t : t.text);
+    const text = getText(task);
+    const exists = this.tasks[project].some(t => getText(t) === text);
+    if (!exists) {
+      this.tasks[project].push(task);
+      this._save();
+    }
   }
 
   async readTasks(project) {
@@ -26,7 +31,11 @@ export class LocalStorageTaskService extends TaskStorage {
   }
 
   async updateTask(project, taskId, updatedTask) {
-    if (this.tasks[project]) {
+    if (!this.tasks[project]) return;
+    const getText = t => (typeof t === 'string' ? t : t.text);
+    const text = getText(updatedTask);
+    const exists = this.tasks[project].some((t, idx) => idx !== taskId && getText(t) === text);
+    if (!exists) {
       this.tasks[project][taskId] = updatedTask;
       this._save();
     }

--- a/src/storage/localStorageTaskService.test.js
+++ b/src/storage/localStorageTaskService.test.js
@@ -23,6 +23,21 @@ describe('LocalStorageTaskService', () => {
     expect(tasks).toEqual(['updated']);
   });
 
+  it('prevents duplicate tasks', async () => {
+    await service.createTask('proj', 'task 1');
+    await service.createTask('proj', 'task 1');
+    const tasks = await service.readTasks('proj');
+    expect(tasks).toEqual(['task 1']);
+  });
+
+  it('prevents updates that duplicate another task', async () => {
+    await service.createTask('proj', 'task 1');
+    await service.createTask('proj', 'task 2');
+    await service.updateTask('proj', 1, 'task 1');
+    const tasks = await service.readTasks('proj');
+    expect(tasks).toEqual(['task 1', 'task 2']);
+  });
+
   it('deletes tasks', async () => {
     await service.createTask('proj', 'task 1');
     await service.deleteTask('proj', 0);

--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -4,23 +4,23 @@ export function parseProjects(markdown) {
   let currentProject = 'General';
 
   for (const line of lines) {
-    // Lines that begin with "# " denote a project heading
-    const headingMatch = line.match(/^#+\s+(.+)$/);
-    if (headingMatch) {
-      currentProject = headingMatch[1].trim();
-      projects[currentProject] = projects[currentProject] || [];
-      continue;
-    }
-
     // Allow Todoist-style project prefix, e.g. "#proj Do something"
     const prefixTag = line.match(/^#([\w-]+)\s+(.+)/);
-    if (prefixTag) {
+    if (prefixTag && prefixTag[2].trim().split(/\s+/).length > 1) {
       const project = prefixTag[1];
       let text = prefixTag[2].trim();
       text = text.replace(/\(0\)/g, '').trim();
 
       if (!projects[project]) projects[project] = [];
       projects[project].push(text);
+      continue;
+    }
+
+    // Lines that begin with "#" denote a project heading (e.g. "#proj")
+    const headingMatch = line.match(/^#+\s*(.+)$/);
+    if (headingMatch) {
+      currentProject = headingMatch[1].trim();
+      projects[currentProject] = projects[currentProject] || [];
       continue;
     }
 


### PR DESCRIPTION
## Summary
- prevent duplicate tasks when creating or updating tasks
- update markdown parser to correctly handle headings and prefix syntax
- fix tests for updated placeholder
- mention deduplication in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685685efe5c083228452fdd08fa133d3