### PR TITLE
Add persistence for completed tasks

### DIFF
--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -27,7 +27,7 @@ export default function TaskItem({ task, onToggle, onDelete, onUpdate }) {
   const isDone = task.done || false;
 
   return (
-    <li className="task-item">
+    <li className={`task-item${isDone ? ' completed' : ''}`}>
       <input
         type="checkbox"
         checked={isDone}
@@ -43,10 +43,7 @@ export default function TaskItem({ task, onToggle, onDelete, onUpdate }) {
           autoFocus
         />
       ) : (
-        <span
-          className={isDone ? 'completed' : ''}
-          onDoubleClick={handleEdit}
-        >
+        <span onDoubleClick={handleEdit}>
           {taskText}
         </span>
       )}

--- a/src/components/TaskItem.test.jsx
+++ b/src/components/TaskItem.test.jsx
@@ -32,4 +32,12 @@ describe('TaskItem inline editing', () => {
     expect(onUpdate).not.toHaveBeenCalled();
     getByText('cancel');
   });
+
+  it('applies completed class when done', () => {
+    const { container } = render(
+      <TaskItem task={{ text: 'done task', done: true }} onToggle={() => {}} onDelete={() => {}} onUpdate={() => {}} />
+    );
+    const li = container.querySelector('li.task-item');
+    expect(li.classList.contains('completed')).toBe(true);
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -115,7 +115,7 @@ body {
   font-weight: 300;
 }
 
-.task-item .completed {
+.task-item.completed span {
   text-decoration: line-through;
   color: #888;
 }
@@ -154,7 +154,7 @@ body {
 
 .completed {
   text-decoration: line-through;
-  opacity: 0.6;
+  opacity: 0.5;
 }
 
 .project-section[data-project] {

--- a/src/storage/localStorageTaskService.test.js
+++ b/src/storage/localStorageTaskService.test.js
@@ -29,4 +29,14 @@ describe('LocalStorageTaskService', () => {
     const tasks = await service.readTasks('proj');
     expect(tasks).toEqual([]);
   });
+
+  it('persists task completion', async () => {
+    const task = { text: 'persist', done: false };
+    await service.createTask('proj', task);
+    await service.updateTask('proj', 0, { ...task, done: true });
+
+    const newService = new LocalStorageTaskService();
+    const tasks = await newService.readTasks('proj');
+    expect(tasks[0]).toEqual({ text: 'persist', done: true });
+  });
 });


### PR DESCRIPTION
## Summary
- apply `completed` class on task list row when done
- style completed rows with 50% opacity
- persist completion state across reloads
- test task row styles and storage persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68568ee046e48322815764aae1dd8473