### PR TITLE
Fix task checkbox persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,8 +67,11 @@ export default function App() {
   const handleToggle = async (project, idx) => {
     setTasks(prev => {
       const updated = { ...prev };
-      const task = { ...updated[project][idx] };
-      task.done = !task.done;
+      const current = updated[project][idx];
+      const task =
+        typeof current === 'object' && current !== null
+          ? { ...current, done: !current.done }
+          : { text: String(current), done: true };
       updated[project][idx] = task;
       storage.updateTask(project, idx, task);
       return updated;

--- a/src/components/TaskItem.test.jsx
+++ b/src/components/TaskItem.test.jsx
@@ -32,4 +32,14 @@ describe('TaskItem inline editing', () => {
     expect(onUpdate).not.toHaveBeenCalled();
     getByText('cancel');
   });
+
+  it('toggles completion', () => {
+    const onToggle = vi.fn();
+    const { getByRole } = render(
+      <TaskItem task={{ text: 'done?', done: false }} onToggle={onToggle} onDelete={() => {}} onUpdate={() => {}} />
+    );
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+    expect(onToggle).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure handleToggle can process plain string tasks
- test checkbox click toggles completion

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856992b510c8322b9672e462e6f9aac