### PR TITLE
Add project colors and update task count layout

### DIFF
--- a/src/components/TaskList.jsx
+++ b/src/components/TaskList.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import TaskItem from './TaskItem.jsx';
+import { getProjectColor } from '../utils/colorUtils.js';
 
 export default function TaskList({ tasksByProject, onToggle, onDelete, onUpdate, onRemoveProject }) {
   const [collapsed, setCollapsed] = useState({});
@@ -16,10 +17,13 @@ export default function TaskList({ tasksByProject, onToggle, onDelete, onUpdate,
           <div key={project} className="project-section" data-project={project}>
             <h3
               className="project-title"
+              style={{ color: getProjectColor(project) }}
               onClick={() => toggle(project)}
             >
-              {'#' + project}
-              <span className="task-count">({tasks.length})</span>
+              <span className="project-name">
+                {'#' + project}
+                <span className="task-count">{tasks.length}</span>
+              </span>
               <button
                 className="remove-project-btn"
                 onClick={(e) => {

--- a/src/index.css
+++ b/src/index.css
@@ -77,7 +77,6 @@ body {
   margin-bottom: 0.25rem;
   border-bottom: 1px solid #e0e0e0;
   padding-bottom: 0.25rem;
-  color: #db4c3f;
   font-weight: 600;
   cursor: pointer;
   display: flex;
@@ -85,10 +84,19 @@ body {
   align-items: center;
 }
 
+.project-name {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .task-count {
-  color: #666;
+  background: #f0f0f0;
+  color: #333;
   font-weight: normal;
-  font-size: 0.85rem;
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
 .task-list ul {

--- a/src/utils/colorUtils.js
+++ b/src/utils/colorUtils.js
@@ -1,0 +1,8 @@
+export function getProjectColor(project) {
+  let hash = 0;
+  for (let i = 0; i < project.length; i++) {
+    hash = project.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 60%, 50%)`;
+}


### PR DESCRIPTION
## Summary
- display the task count directly next to the project name
- give each project a unique color

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856c2d542d48322b72e8e6d6f622f11