### PR TITLE
Adjust markdown input layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
 }
 
 .input-panel {
@@ -66,11 +67,18 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-weight: 600;
-  align-self: flex-start;
+  align-self: flex-end;
 }
 
 .generate-button:hover {
   background: #c1342b;
+}
+
+@media (max-width: 639px) {
+  .generate-button {
+    width: 100%;
+    align-self: center;
+  }
 }
 
 .project-title {


### PR DESCRIPTION
## Summary
- ensure markdown input stretches full width of the column
- right-align the generate button on desktop
- center the button and make it full width on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580768d6e48322989d0ccfb6768f39