### PR TITLE
Taller textarea and Add note button alignment

### DIFF
--- a/src/components/MarkdownTaskInput.jsx
+++ b/src/components/MarkdownTaskInput.jsx
@@ -17,12 +17,12 @@ export default function MarkdownTaskInput({ value, onChange, onGenerate, isGener
         placeholder="Enter markdown with tasks... (Press Enter to generate)"
         disabled={isGenerating}
       />
-      <button 
-        className="generate-button" 
+      <button
+        className="generate-button"
         onClick={onGenerate}
         disabled={isGenerating}
       >
-        {isGenerating ? 'Generating...' : 'Generate Tasks'}
+        {isGenerating ? 'Generating...' : 'Add Note'}
       </button>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ body {
 .markdown-input textarea {
   flex: 1;
   width: 100%;
-  height: 200px;
+  height: 300px;
   margin-bottom: 0.5rem;
   background: #fff;
   color: #333;
@@ -66,11 +66,19 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-weight: 600;
-  align-self: flex-start;
+  align-self: flex-end;
 }
 
 .generate-button:hover {
   background: #c1342b;
+}
+
+@media (max-width: 639px) {
+  .generate-button {
+    align-self: stretch;
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .project-title {


### PR DESCRIPTION
## Summary
- make markdown input taller and align Add Note button under it
- center button on small screens
- rename Generate Tasks button text to Add Note

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858098d1ec48322a2c79d8d2e7eba4b